### PR TITLE
Skip redirection when is not required

### DIFF
--- a/ckanext/saml2/plugin.py
+++ b/ckanext/saml2/plugin.py
@@ -395,8 +395,10 @@ class Saml2Plugin(p.SingletonPlugin):
                 if came_from:
                     h.redirect_to(h.url_for(came_from))
 
-            redirect_after_login = config.get('saml2.redirect_after_login', '/dashboard')
-            h.redirect_to(redirect_after_login)
+            # TODO CKAN identify user in all requests. Discover why this is here
+            if '/login' in request.url:
+                redirect_after_login = config.get('saml2.redirect_after_login', '/dashboard')
+                h.redirect_to(redirect_after_login)
 
     def _create_or_update_user(self, user_name, saml_info, name_id):
         """Create or update the subject's user account and return the user


### PR DESCRIPTION
related to [Multi#538](https://github.com/GSA/datagov-ckan-multi/issues/538)

This PR skips the redirection that is causing problems

### Notes

CKAN identify before each request. `ckanext-saml2` redirect on all POSTs

Months ago @amercader from [CKAN changed](https://github.com/GSA/ckan/commit/546920e331e09469a8520e1daf2dec339ba0b478) something related to requests. Maybe is related to this error

I assume this is not failing from CKAN 2.3